### PR TITLE
Fix gem loading and remove deprecations

### DIFF
--- a/grape-kaminari.gemspec
+++ b/grape-kaminari.gemspec
@@ -25,4 +25,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"
   spec.add_development_dependency 'rspec', '~> 2.9'
+  spec.add_development_dependency 'rack-test'
 end

--- a/lib/grape/kaminari.rb
+++ b/lib/grape/kaminari.rb
@@ -1,7 +1,6 @@
 require "grape"
 require "grape/kaminari/version"
 require "grape/kaminari/max_value_validator"
-require "kaminari/grape"
 
 module Grape
   module Kaminari

--- a/spec/kaminari_spec.rb
+++ b/spec/kaminari_spec.rb
@@ -35,7 +35,7 @@ describe Grape::Kaminari do
         subject.paginate
         subject.get '/' do; end
       end
-      let(:params) {subject.routes.first.route_params}
+      let(:params) {subject.routes.first.params}
 
       it 'does not require :page' do
         expect(params['page'][:required]).to eq(false)
@@ -98,7 +98,7 @@ describe Grape::Kaminari do
       subject.paginate per_page:99, max_per_page: 999, offset: 9
       subject.get '/' do; end
     end
-    let(:params) {subject.routes.first.route_params}
+    let(:params) {subject.routes.first.params}
 
     it 'defaults :per_page to customized value' do
       expect(params['per_page'][:default]).to eq(99)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -14,6 +14,5 @@ I18n.enforce_available_locales = false
 
 RSpec.configure do |config|
   config.include Rack::Test::Methods
-  config.treat_symbols_as_metadata_keys_with_true_values = true
   config.order = 'random'
 end


### PR DESCRIPTION
`require "kaminari/grape"` removed due to loading error `Uncaught exception: cannot load such file -- kaminari/grape`

`rack-test` added due to running spec error `cannot load such file -- rack/test (LoadError)`

`params` used instead of `route_params` due to deprecation message

`treat_symbols_as_metadata_keys_with_true_values` removed due to deprecation message